### PR TITLE
Correct development info that might be misinterpreted

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
                     <br />for visual effects and motion graphics industry</h3>
                     <p class="custom_paragaraph">Natron is a powerful Digital Compositor that can handle all of your 2D/2.5D needs. Its robust OIIO file formats and OpenFX architecture is what make Natron the most flexible open source compositor for the visual effects community. Its interface and functionally are the same across all platforms such as macOS, Linux and Windows. Natron has a powerful keying, roto/rotopaint, 2D tracking tools that are staple for all current film production project that requires visual effects.
                     </p>
-                    <p class="custom_paragaraph">The development of Natron was supported by <a href="https://www.inria.fr">Inria</a> from 2013 to 2018.
+                    <p class="custom_paragaraph">Natron was a proud recipient of <a href="https://www.inria.fr">Inria</a> funding from 2013 to 2018, and is now actively developed by its community.
                     <br />
                     <img src="img/inr_logo_gris.png" alt="Inria logo" width=161 height=57 />
                     </p>

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
                     <br />for visual effects and motion graphics industry</h3>
                     <p class="custom_paragaraph">Natron is a powerful Digital Compositor that can handle all of your 2D/2.5D needs. Its robust OIIO file formats and OpenFX architecture is what make Natron the most flexible open source compositor for the visual effects community. Its interface and functionally are the same across all platforms such as macOS, Linux and Windows. Natron has a powerful keying, roto/rotopaint, 2D tracking tools that are staple for all current film production project that requires visual effects.
                     </p>
-                    <p class="custom_paragaraph">Natron was a proud recipient of <a href="https://www.inria.fr">Inria</a> funding from 2013 to 2018, and is now actively developed by its community.
+                    <p class="custom_paragaraph">Natron was a proud recipient of <a href="https://www.inria.fr" target="_blank">Inria</a> funding from 2013 to 2018, and is now actively developed by its community.
                     <br />
                     <img src="img/inr_logo_gris.png" alt="Inria logo" width=161 height=57 />
                     </p>


### PR DESCRIPTION
## PR Description

The original website contained this on its landing page:

> The development of Natron was supported by Inria from 2013 to 2018. 

Unfortunately, that could be misinterpreted to mean "Natron's development ended in 2018". To clarify the original meaning and intent of the passage, I changed it to this:

> Natron was a proud recipient of [Inria](https://www.inria.fr)  funding from 2013 to 2018, and is now actively developed by its community.